### PR TITLE
add resize height in spread

### DIFF
--- a/src/examples/EventReceive.tsx
+++ b/src/examples/EventReceive.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Divider } from 'antd';
+import { Button, Divider, Form, Select } from 'antd';
 import { Wrapper, Segment } from 'components';
 import { DataGrid } from 'axui-datagrid';
 
@@ -34,6 +34,23 @@ class EventReceive extends React.Component<any, any> {
     });
   };
 
+  changeConfig = (props: any, value: any) => {
+    const processor = {
+      setHeight: () => {
+        this.setState({
+          height: value,
+        });
+      },
+    };
+
+    if (props in processor) {
+      processor[props].call(this, value);
+    } else {
+      this.setState(value);
+    }
+  };
+
+
   render() {
     return (
       <Wrapper>
@@ -59,6 +76,28 @@ class EventReceive extends React.Component<any, any> {
             style={{ width: '100%', height: '400px', padding: '10px' }}
             value={this.state.eventLog.join('\n')}
           />
+
+          <Divider />
+
+        <Button
+          type="primary"
+          onClick={() => this.changeConfig('setHeight', 300)}
+        >
+          height : 300
+        </Button>
+        <Button
+          type="primary"
+          onClick={() => this.changeConfig('setHeight', 400)}
+        >
+          height : 400"
+        </Button>
+        <Button
+          type="primary"
+          onClick={() => this.changeConfig('setHeight', 500)}
+        >
+          height : 500"
+        </Button>
+
         </Segment>
       </Wrapper>
     );

--- a/src/examples/FootSum.tsx
+++ b/src/examples/FootSum.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-
+import { Button, Divider, Form, Select } from 'antd';
 import { Wrapper, Segment } from 'components';
 import { DataGrid, utils } from 'axui-datagrid';
 import {
@@ -72,6 +72,23 @@ class FootSum extends React.Component<any, any> {
     };
   }
 
+  changeConfig = (props: any, value: any) => {
+    const processor = {
+      setHeight: () => {
+        this.setState({
+          height: value,
+        });
+      },
+    };
+
+    if (props in processor) {
+      processor[props].call(this, value);
+    } else {
+      this.setState(value);
+    }
+  };
+
+
   public render() {
     return (
       <Wrapper>
@@ -91,6 +108,30 @@ class FootSum extends React.Component<any, any> {
             data={this.state.data}
             options={this.state.options}
           />
+
+        <Divider />
+        
+        <Button
+          type="primary"
+          onClick={() => this.changeConfig('setHeight', 300)}
+        >
+          height : 300
+        </Button>
+        <Button
+          type="primary"
+          onClick={() => this.changeConfig('setHeight', 400)}
+        >
+          height : 400"
+        </Button>
+        <Button
+          type="primary"
+          onClick={() => this.changeConfig('setHeight', 500)}
+        >
+          height : 500"
+        </Button>
+
+
+
         </Segment>
       </Wrapper>
     );

--- a/src/examples/InlineEdit.tsx
+++ b/src/examples/InlineEdit.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { Button, Divider, Form, Select } from 'antd';
 import { Wrapper, Segment } from 'components';
 import { DataGrid } from 'axui-datagrid';
 
@@ -37,6 +38,22 @@ class InlineEdit extends React.Component<any, any> {
     };
   }
 
+  changeConfig = (props: any, value: any) => {
+    const processor = {
+      setHeight: () => {
+        this.setState({
+          height: value,
+        });
+      },
+    };
+
+    if (props in processor) {
+      processor[props].call(this, value);
+    } else {
+      this.setState(value);
+    }
+  };
+
   public render() {
     return (
       <Wrapper>
@@ -54,8 +71,33 @@ class InlineEdit extends React.Component<any, any> {
             data={this.state.data}
             options={this.state.options}
           />
+
+          <Divider />
+        
+          <Button
+            type="primary"
+            onClick={() => this.changeConfig('setHeight', 300)}
+          >
+            height : 300
+          </Button>
+          <Button
+            type="primary"
+            onClick={() => this.changeConfig('setHeight', 400)}
+          >
+            height : 400"
+          </Button>
+          <Button
+            type="primary"
+            onClick={() => this.changeConfig('setHeight', 500)}
+          >
+            height : 500"
+          </Button>
+
+
         </Segment>
       </Wrapper>
+      
+
     );
   }
 }

--- a/src/examples/LoadingState.tsx
+++ b/src/examples/LoadingState.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Divider, Checkbox } from 'antd';
+import { Divider, Checkbox, Button,Form, Select} from 'antd';
 import { Wrapper, Segment } from 'components';
 import { DataGrid } from 'axui-datagrid';
 
@@ -38,6 +38,23 @@ class LoadingState extends React.Component<any, any> {
         data: [...this.state.data, ...appendData],
       });
     }, 1000);
+  };
+
+
+  changeConfig = (props: any, value: any) => {
+    const processor = {
+      setHeight: () => {
+        this.setState({
+          height: value,
+        });
+      },
+    };
+
+    if (props in processor) {
+      processor[props].call(this, value);
+    } else {
+      this.setState(value);
+    }
   };
 
   render() {
@@ -80,6 +97,26 @@ class LoadingState extends React.Component<any, any> {
           >
             loadingData
           </Checkbox>
+          <Divider />
+
+<Button
+  type="primary"
+  onClick={() => this.changeConfig('setHeight', 300)}
+>
+  height : 300
+</Button>
+<Button
+  type="primary"
+  onClick={() => this.changeConfig('setHeight', 400)}
+>
+  height : 400"
+</Button>
+<Button
+  type="primary"
+  onClick={() => this.changeConfig('setHeight', 500)}
+>
+  height : 500"
+</Button>
         </Segment>
       </Wrapper>
     );

--- a/src/examples/MultiColumnHeader.tsx
+++ b/src/examples/MultiColumnHeader.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { Button, Divider, Form, Select } from 'antd';
 import { Wrapper, Segment } from 'components';
 import { DataGrid } from 'axui-datagrid';
 
@@ -30,7 +31,24 @@ class MultiColumnHeader extends React.Component<any, any> {
         },
       },
     };
+    
   }
+
+  changeConfig = (props: any, value: any) => {
+    const processor = {
+      setHeight: () => {
+        this.setState({
+          height: value,
+        });
+      },
+    };
+
+    if (props in processor) {
+      processor[props].call(this, value);
+    } else {
+      this.setState(value);
+    }
+  };
 
   public render() {
     return (
@@ -49,6 +67,28 @@ class MultiColumnHeader extends React.Component<any, any> {
             data={this.state.data}
             options={this.state.options}
           />
+        
+        <Divider />
+
+          <Button
+            type="primary"
+            onClick={() => this.changeConfig('setHeight', 300)}
+          >
+            height : 300
+          </Button>
+          <Button
+            type="primary"
+            onClick={() => this.changeConfig('setHeight', 400)}
+          >
+            height : 400"
+          </Button>
+          <Button
+            type="primary"
+            onClick={() => this.changeConfig('setHeight', 500)}
+          >
+            height : 500"
+          </Button>
+          
         </Segment>
       </Wrapper>
     );

--- a/src/examples/RowSelector.tsx
+++ b/src/examples/RowSelector.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Divider } from 'antd';
+import { Divider,Form, Select, Button } from 'antd';
 import { Wrapper, Segment } from 'components';
 import { DataGrid } from 'axui-datagrid';
 
@@ -23,6 +23,23 @@ class LoadingState extends React.Component<any, any> {
       options: {},
     };
   }
+
+  changeConfig = (props: any, value: any) => {
+    const processor = {
+      setHeight: () => {
+        this.setState({
+          height: value,
+        });
+      },
+    };
+
+    if (props in processor) {
+      processor[props].call(this, value);
+    } else {
+      this.setState(value);
+    }
+  };
+
 
   render() {
     const { height, columns, data, options } = this.state;
@@ -60,6 +77,29 @@ class LoadingState extends React.Component<any, any> {
             value={JSON.stringify(this.state.filteredList)}
             readOnly
           />
+          <Divider />
+
+          <Button
+            type="primary"
+            onClick={() => this.changeConfig('setHeight', 300)}
+          >
+            height : 300
+          </Button>
+          <Button
+            type="primary"
+            onClick={() => this.changeConfig('setHeight', 400)}
+          >
+            height : 400"
+          </Button>
+          <Button
+            type="primary"
+            onClick={() => this.changeConfig('setHeight', 500)}
+          >
+            height : 500"
+          </Button>
+
+
+
         </Segment>
       </Wrapper>
     );


### PR DESCRIPTION
example 내의 카테고리 중 상위 4개의 카테고리 제외한 다른 부분에는 크기를 조정하는 부분이 없어서 
300,400,500으로 조정할 수 있도록 수정하였습니다.