### PR TITLE
Adding Select list by data size from  FrozenColumnRow

### DIFF
--- a/src/examples/FrozenColumnRow.tsx
+++ b/src/examples/FrozenColumnRow.tsx
@@ -81,7 +81,7 @@ class FrozenColumnRow extends React.Component<any, any> {
                 labelInValue
                 defaultValue={
                   {
-                    key: '' + this.state.options.frozenRowIndex,
+                    key: '' + this.state.options.frozenRowIndex+" row",
                   } as any
                 }
                 onChange={(value: any) => {
@@ -90,19 +90,16 @@ class FrozenColumnRow extends React.Component<any, any> {
                   });
                 }}
               >
-                <Select.Option value="0">0 row</Select.Option>
-                <Select.Option value="1">1 row</Select.Option>
-                <Select.Option value="2">2 row</Select.Option>
-                <Select.Option value="3">3 row</Select.Option>
-                <Select.Option value="4">4 row</Select.Option>
-                <Select.Option value="5">5 row</Select.Option>
+                {this.state.data.map((some:any,i:number)=>{
+                return <Select.Option key="" value={i}>{i} row</Select.Option>;
+              })}
               </Select>
             </Form.Item>
             <Form.Item id={'col'} label={'Column'}>
               <Select
                 labelInValue
                 defaultValue={
-                  { key: '' + this.state.options.frozenColumnIndex } as any
+                  { key: '' + this.state.options.frozenColumnIndex+" column" } as any
                 }
                 onChange={(value: any) => {
                   this.changeConfig('setOptions', {
@@ -110,12 +107,9 @@ class FrozenColumnRow extends React.Component<any, any> {
                   });
                 }}
               >
-                <Select.Option value="0">0 column</Select.Option>
-                <Select.Option value="1">1 column</Select.Option>
-                <Select.Option value="2">2 column</Select.Option>
-                <Select.Option value="3">3 column</Select.Option>
-                <Select.Option value="4">4 column</Select.Option>
-                <Select.Option value="5">5 column</Select.Option>
+                {this.state.columns.map((some:any,i:number)=>{
+                return <Select.Option key="" value={i}>{i} column</Select.Option>;
+              })}
               </Select>
             </Form.Item>
           </Form>


### PR DESCRIPTION
FrozenColumnRow에서 고정시킬수 있는 행과 열의 Select가 각각 5개씩만 있어서 데이터 크기만큼 Select option을 추가하여 수정하였습니다.  

저번에 Spread sheet에서 행을 골라 고정시킬 수 있도록 하는 방법을 제시해주셨는데 컨텍스트 메뉴가 필요할 것같아서 컨텍스트 메뉴를 건들이면서 다시 수정할 수 있도록 해보겠습니다!